### PR TITLE
Fix formatting issues in /macro find

### DIFF
--- a/src/main/java/dev/gnomebot/app/discord/command/MacroCommands.java
+++ b/src/main/java/dev/gnomebot/app/discord/command/MacroCommands.java
@@ -250,7 +250,7 @@ public class MacroCommands extends ApplicationCommands {
 		if (list.isEmpty()) {
 			event.respond("No macros found!");
 		} else {
-			event.respond(list.stream().map(m -> m.name).collect(Collectors.joining(" • ")));
+			event.respond(list.stream().map(m -> m.name.replaceAll("_", "\\_")).collect(Collectors.joining(" • ")));
 		}
 	}
 


### PR DESCRIPTION
This simple change replaces `_` with `\_` to prevent underscores and italics caused by `_` in macro names. A macro like `__basic_probejs` is fine on its own, but if there are multiple displayed in one message, like `/macro find` does, this requires them to be escaped, or they'll get formatted unintentionally.