### PR TITLE
Macro Aliases

### DIFF
--- a/src/main/java/dev/gnomebot/app/data/ContentType.java
+++ b/src/main/java/dev/gnomebot/app/data/ContentType.java
@@ -82,10 +82,12 @@ public abstract class ContentType {
 		content = content.trim();
 
 		var inl = content.indexOf('\n');
+
 		if (inl == -1) {
 			return Pair.of(TEXT, content);
 		} else {
 			var first = content.substring(0, content.indexOf('\n')).replace(" ", "");
+
 			return switch (first) {
 				case "//cpx", "//complex" -> Pair.of(COMPLEX, ComplexMessage.parse(gc, content));
 				case "//js", "//javascript" -> Pair.of(JS, content);

--- a/src/main/java/dev/gnomebot/app/data/ContentType.java
+++ b/src/main/java/dev/gnomebot/app/data/ContentType.java
@@ -37,6 +37,18 @@ public abstract class ContentType {
 		}
 	};
 
+	public static final ContentType MACRO_ALIAS = new ContentType("macro-alias") {
+		@Override
+		public MessageBuilder render(GuildCollections gc, @Nullable CommandReader reader, Object cached, long sender) {
+			var name = String.valueOf(cached).split("\n")[1].trim();
+			var macro = gc.getMacro(name);
+			if (macro == null) return MessageBuilder.create("Macro `" + name + "` doesn't exist!").noComponents().noEmbeds();
+			var macroType = ContentType.parse(gc, macro.getContent());
+			if (macroType.a().name.equals("macro-alias")) return MessageBuilder.create("You can't create an alias of an alias!").noComponents().noEmbeds();
+			return macroType.a().render(gc, reader, macroType.b(), sender);
+		}
+	};
+
 	public final String name;
 
 	public ContentType(String name) {
@@ -70,16 +82,15 @@ public abstract class ContentType {
 		content = content.trim();
 
 		var inl = content.indexOf('\n');
-
 		if (inl == -1) {
 			return Pair.of(TEXT, content);
 		} else {
 			var first = content.substring(0, content.indexOf('\n')).replace(" ", "");
-
 			return switch (first) {
 				case "//cpx", "//complex" -> Pair.of(COMPLEX, ComplexMessage.parse(gc, content));
 				case "//js", "//javascript" -> Pair.of(JS, content);
-				case "//macro-bundle" -> Pair.of(MACRO_BUNDLE, MacroBundle.parse(gc, content));
+				case "//macro-bundle", "//bundle" -> Pair.of(MACRO_BUNDLE, MacroBundle.parse(gc, content));
+				case "//macro-alias", "//alias" -> Pair.of(MACRO_ALIAS, content);
 				default -> Pair.of(TEXT, content);
 			};
 		}


### PR DESCRIPTION
This PR adds a new macro type - `macro-alias` which allows the creation of a macro which references another macro and returns its content.

For example let's say that there's a macro called `hello`:
```
Hello World!
```

And than another called `hi`:
```
// macro-alias
hello
```

Running `hi` would be the same as running `hello`