### PR TITLE
Moved mclo.gs paste loading fully to the client side. Fixed #L.

### DIFF
--- a/resources/assets/paste.js
+++ b/resources/assets/paste.js
@@ -1,5 +1,6 @@
 const pasteTitleTag = document.getElementById('paste-title');
 const pasteTextTag = document.getElementById('paste-text');
+const pasteHeaderTag = document.querySelector("div.content > h1");
 let pasteFilename = pasteTextTag.dataset.pasteFilename;
 const pasteUrl = pasteTextTag.dataset.pasteUrl;
 const pasteContentType = pasteTextTag.dataset.pasteContentType;
@@ -70,8 +71,16 @@ function updatePasteFilename(filename) {
 	pasteFilename = filename;
 	pasteTextTag.dataset.pasteFilename = filename;
 
-	if (pasteTitleTag.firstChild !== null && pasteTitleTag.firstChild.nodeType === Node.TEXT_NODE) {
+	if (pasteHeaderTag !== null) {
+		pasteHeaderTag.textContent = filename;
+	}
+
+	if (pasteTitleTag.firstChild === null) {
+		pasteTitleTag.appendChild(document.createTextNode(filename));
+	} else if (pasteTitleTag.firstChild.nodeType === Node.TEXT_NODE) {
 		pasteTitleTag.firstChild.textContent = filename;
+	} else {
+		pasteTitleTag.insertBefore(document.createTextNode(filename), pasteTitleTag.firstChild);
 	}
 }
 
@@ -87,6 +96,16 @@ function scrollToLocationHash() {
 	}
 }
 
+function readMclogsRawError(status) {
+	updatePasteFilename("Error " + status);
+	return fetch(pasteUrl.replace("/1/log/", "/1/raw/").split("?", 1)[0]).then(response => {
+		return response.text();
+	}).catch(error => {
+		updatePasteFilename("Error");
+		return error.toString();
+	});
+}
+
 if (pasteContentType.startsWith("image/")) {
 	const img = document.createElement("img");
 	img.src = pasteUrl;
@@ -96,18 +115,27 @@ if (pasteContentType.startsWith("image/")) {
 	video.src = pasteUrl;
 	pasteTextTag.appendChild(video);
 } else {
-	const pasteText = !pasteUrl.startsWith("https://api.mclo.gs/1/log/") ? fetch(pasteUrl).then(response => response.text()) : fetch(pasteUrl).then(response => response.json()).then(json => {
-		if (json.success === false) {
-			return json.error ?? "";
+	const pasteText = !pasteUrl.startsWith("https://api.mclo.gs/1/log/") ? fetch(pasteUrl).then(response => response.text()) : fetch(pasteUrl).then(response => {
+		if (!response.ok) {
+			return readMclogsRawError(response.status);
 		}
 
-		const insights = json.content?.insights;
+		return response.json().then(json => {
+			if (json.success === false) {
+				return readMclogsRawError(response.status);
+			}
 
-		if (insights?.title !== undefined) {
-			updatePasteFilename(insights.title + ".log");
-		}
+			const insights = json.content?.insights;
 
-		return json.content?.raw ?? "";
+			if (insights?.title !== undefined) {
+				updatePasteFilename(insights.title + ".log");
+			}
+
+			return json.content?.raw ?? "";
+		});
+	}).catch(error => {
+		updatePasteFilename("Error");
+		return error.toString();
 	});
 
 	pasteText.then(text => {

--- a/resources/assets/paste.js
+++ b/resources/assets/paste.js
@@ -1,6 +1,6 @@
 const pasteTitleTag = document.getElementById('paste-title');
 const pasteTextTag = document.getElementById('paste-text');
-const pasteFilename = pasteTextTag.dataset.pasteFilename;
+let pasteFilename = pasteTextTag.dataset.pasteFilename;
 const pasteUrl = pasteTextTag.dataset.pasteUrl;
 const pasteContentType = pasteTextTag.dataset.pasteContentType;
 const pasteZipPath = pasteTextTag.dataset.zipPath;
@@ -62,6 +62,31 @@ function readPasteLines(text) {
 	return lines;
 }
 
+function updatePasteFilename(filename) {
+	if (filename.length === 0) {
+		return;
+	}
+
+	pasteFilename = filename;
+	pasteTextTag.dataset.pasteFilename = filename;
+
+	if (pasteTitleTag.firstChild !== null && pasteTitleTag.firstChild.nodeType === Node.TEXT_NODE) {
+		pasteTitleTag.firstChild.textContent = filename;
+	}
+}
+
+function scrollToLocationHash() {
+	if (location.hash.length > 1) {
+		const hash = location.hash;
+		const tag = document.getElementById(location.hash.substring(1));
+
+		if (tag !== null) {
+			history.replaceState(null, "", location.pathname + location.search);
+			location.hash = hash;
+		}
+	}
+}
+
 if (pasteContentType.startsWith("image/")) {
 	const img = document.createElement("img");
 	img.src = pasteUrl;
@@ -71,7 +96,21 @@ if (pasteContentType.startsWith("image/")) {
 	video.src = pasteUrl;
 	pasteTextTag.appendChild(video);
 } else {
-	fetch(pasteUrl).then(response => response.text()).then(text => {
+	const pasteText = !pasteUrl.startsWith("https://api.mclo.gs/1/log/") ? fetch(pasteUrl).then(response => response.text()) : fetch(pasteUrl).then(response => response.json()).then(json => {
+		if (json.success === false) {
+			return json.error ?? "";
+		}
+
+		const insights = json.content?.insights;
+
+		if (insights?.title !== undefined) {
+			updatePasteFilename(insights.title + ".log");
+		}
+
+		return json.content?.raw ?? "";
+	});
+
+	pasteText.then(text => {
 		pasteTextTag.innerHTML = ""
 		// console.log("Received " + text + " (" + text.length + ")")
 
@@ -213,5 +252,7 @@ if (pasteContentType.startsWith("image/")) {
 			appendText(link, " [Minecraft Profile]");
 			pasteTitleTag.appendChild(link);
 		}
+
+		scrollToLocationHash();
 	})
 }

--- a/src/main/java/dev/gnomebot/app/server/handler/PasteHandlers.java
+++ b/src/main/java/dev/gnomebot/app/server/handler/PasteHandlers.java
@@ -10,7 +10,6 @@ import dev.gnomebot.app.util.MessageId;
 import dev.gnomebot.app.util.SnowFlake;
 import dev.gnomebot.app.util.URLRequest;
 import dev.latvian.apps.ansi.log.Log;
-import dev.latvian.apps.json.JSON;
 import dev.latvian.apps.tinyhttp.content.MimeType;
 import dev.latvian.apps.tinyhttp.http.response.HTTPResponse;
 import dev.latvian.apps.tinyhttp.http.response.error.client.ForbiddenError;
@@ -28,7 +27,6 @@ import discord4j.discordjson.json.MessageData;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -190,20 +188,7 @@ public class PasteHandlers {
 
 	public static HTTPResponse pasteMclogs(AppRequest req) {
 		var id = req.variable("id").asString();
-
-		String filename = "unknown.log";
-
-		try {
-			var request = App.HTTP_CLIENT.send(App.request("https://api.mclo.gs/1/insights/" + id).timeout(Duration.ofSeconds(3L)).build(), HttpResponse.BodyHandlers.ofString());
-
-			if (request.statusCode() / 100 == 2) {
-				var json = JSON.DEFAULT.read(request.body()).readObject();
-				filename = json.asString("title") + ".log";
-			} else {
-				throw new NotFoundError("File not found!");
-			}
-		} catch (Exception _) {
-		}
+		var filename = "mclo.gs/" + id;
 
 		var root = req.createRoot(filename);
 		root.head.deferScript("/assets/paste.js" + AppRootTag.RESOURCE_REFRESH); // + "_%08x".formatted(UUID.randomUUID().hashCode()));
@@ -216,7 +201,7 @@ public class PasteHandlers {
 				.id("paste-text")
 				.classes("pastetext")
 				.attr("data-paste-filename", filename)
-				.attr("data-paste-url", "https://api.mclo.gs/1/raw/" + id)
+				.attr("data-paste-url", "https://api.mclo.gs/1/log/" + id + "?raw&insights")
 				.attr("data-paste-content-type", MimeType.TEXT)
 				.attr("data-zip-path", "")
 				.h3().spanstr("Loading...");

--- a/src/main/java/dev/gnomebot/app/server/handler/PasteHandlers.java
+++ b/src/main/java/dev/gnomebot/app/server/handler/PasteHandlers.java
@@ -188,7 +188,7 @@ public class PasteHandlers {
 
 	public static HTTPResponse pasteMclogs(AppRequest req) {
 		var id = req.variable("id").asString();
-		var filename = "mclo.gs/" + id;
+		var filename = "Loading...";
 
 		var root = req.createRoot(filename);
 		root.head.deferScript("/assets/paste.js" + AppRootTag.RESOURCE_REFRESH); // + "_%08x".formatted(UUID.randomUUID().hashCode()));


### PR DESCRIPTION
Moved mclo.gs paste loading fully to the client side. The server no longer requests mclo.gs data; the browser fetches the combined log response directly.
Fixed links like `#L38` now work correctly: the page scrolls to the target line and the existing target highlight is applied.
It wasn't worked at all after you moved raw text loading into the browser side. 